### PR TITLE
rockchip-iqfiles-rk3399: add an alternative name for rkisp-engine

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Priority: optional
 Replaces: rockchip-iqfiles,
 Breaks: rockchip-iqfiles,
 Provides: rockchip-iqfiles,
-Depends: rkisp-engine,
+Depends: rkisp-engine | camera-engine-rkisp,
          ${misc:Depends},
 Description: Additional camera tuning profiles for Rockchip RK3399
  This package contains additional camera tuning profiles that is not


### PR DESCRIPTION
The package `rkisp-engine` is now named `camera-engine-rkisp`.